### PR TITLE
Annotate functions with `explicit`, `[[noreturn]]` and `[[nodiscard]]`

### DIFF
--- a/src/indexer/MatcherUtils.cpp
+++ b/src/indexer/MatcherUtils.cpp
@@ -94,7 +94,7 @@ void fillNamespace(hdoc::types::Symbol& s, const clang::NamedDecl* d, const hdoc
 bool isInIgnoreList(const clang::Decl* d, const hdoc::types::Config* cfg) {
 
   // handle path-based ignore
-  const auto ignorePaths = cfg->ignorePaths; 
+  const auto ignorePaths = cfg->ignorePaths;
   const auto rootDir = cfg->rootDir;
 
   const auto fileLoc = d->getASTContext().getSourceManager().getFileLoc(d->getLocation()); // Resolves macro locations
@@ -215,8 +215,11 @@ std::string getFunctionSignature(hdoc::types::FunctionSymbol& f) {
   f.postTemplate = signature.size();
 
   // Various qualifiers
+  signature += f.isNoDiscard ? "[[nodiscard]] " : "";
   signature += f.storageClass == clang::SC_Static ? "static " : "";
   signature += f.storageClass == clang::SC_Extern ? "extern " : "";
+  signature += f.isExplicit ? "explicit " : "";
+  signature += f.isNoReturn ? "[[noreturn]] " : "";
   signature += f.isInline ? "inline " : "";
   signature += f.isVirtual ? "virtual " : "";
   signature += f.isConstexpr ? "constexpr " : "";

--- a/src/indexer/Matchers.cpp
+++ b/src/indexer/Matchers.cpp
@@ -94,7 +94,10 @@ void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::Ma
   fillOutSymbol(f, res, this->cfg->rootDir);
 
   // Determine if the function is a conversion operator early, since it influences proto generation
-  f.isConversionOp = llvm::isa<clang::CXXConversionDecl>(res);
+  if (const auto* conversion = llvm::dyn_cast<clang::CXXConversionDecl>(res)) {
+    f.isConversionOp = true;
+    f.isExplicit     = conversion->isExplicit();
+  }
 
   // Get a bunch of qualifiers
   f.isVariadic   = res->isVariadic();
@@ -102,9 +105,15 @@ void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::Ma
   f.isConstexpr  = res->isConstexprSpecified() && !res->isExplicitlyDefaulted();
   f.isConsteval  = res->isConsteval();
   f.isInline     = res->isInlineSpecified();
-  f.isNoExcept   = clang::isNoexceptExceptionSpec(res->getExceptionSpecType());
+  f.isNoDiscard  = res->hasAttr<clang::WarnUnusedResultAttr>();
+  f.isNoExcept   = clang::isNoexceptExceptionSpec(res->getExceptionSpecType()); // TODO incorrect - may be parameterized!
+  f.isNoReturn   = res->isNoReturn();
   f.storageClass = res->getStorageClass();
   f.access       = res->getAccess();
+
+  if (const auto ctor = llvm::dyn_cast<clang::CXXConstructorDecl>(res)) {
+    f.isExplicit = ctor->isExplicit();
+  }
 
   // Get ref qualifiers
   if (const auto* fp = res->getType()->getAs<clang::FunctionProtoType>()) {
@@ -271,7 +280,7 @@ std::vector<std::string> templateArgsToStrings(const clang::TemplateArgumentList
             replacement = decl->getNameAsString();
           }
           // If we still don't have anything here, we are dealing with a param which no longer has a name at this point
-          // we try to look up its name in the template params of the record we are currently processing 
+          // we try to look up its name in the template params of the record we are currently processing
           if(replacement == "") {
             auto idx = templateType->getIndex();
             if(idx < record.templateParams.size()) {
@@ -439,7 +448,7 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
   }
 
   // For template specializations, include the template arguments in the name
-  // We do this after the template handling above, so we can re-use the TemplateTypeParm names 
+  // We do this after the template handling above, so we can re-use the TemplateTypeParm names
   // stored for c for those template arguments which were *not* specialized and are represented
   // as canonical ("type-parameter-*") in the template argument list
   if (const auto* spec = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(res)) {

--- a/src/serde/JSONDeserializer.cpp
+++ b/src/serde/JSONDeserializer.cpp
@@ -121,7 +121,10 @@ hdoc::types::FunctionSymbol JSONDeserializer::deserializeFunctionSymbol(const ra
   s.isRecordMember       = obj["isRecordMember"].GetBool();
   s.isConstexpr          = obj["isConstexpr"].GetBool();
   s.isConsteval          = obj["isConsteval"].GetBool();
+  s.isExplicit           = obj["isExplicit"].GetBool();
   s.isInline             = obj["isInline"].GetBool();
+  s.isNoDiscard          = obj["isNoDiscard"].GetBool();
+  s.isNoReturn           = obj["isNoReturn"].GetBool();
   s.isConst              = obj["isConst"].GetBool();
   s.isVolatile           = obj["isVolatile"].GetBool();
   s.isRestrict           = obj["isRestrict"].GetBool();

--- a/src/serde/JSONSerializer.hpp
+++ b/src/serde/JSONSerializer.hpp
@@ -71,8 +71,14 @@ public:
     writer.Bool(f.isConstexpr);
     writer.String("isConsteval");
     writer.Bool(f.isConsteval);
+    writer.String("isExplicit");
+    writer.Bool(f.isExplicit);
     writer.String("isInline");
     writer.Bool(f.isInline);
+    writer.String("isNoDiscard");
+    writer.Bool(f.isNoDiscard);
+    writer.String("isNoReturn");
+    writer.Bool(f.isNoReturn);
     writer.String("isConst");
     writer.Bool(f.isConst);
     writer.String("isVolatile");

--- a/src/types/Symbols.hpp
+++ b/src/types/Symbols.hpp
@@ -159,7 +159,10 @@ public:
   bool                       isRecordMember    = false; ///< Is it a method?
   bool                       isConstexpr       = false; ///< Is it marked constexpr?
   bool                       isConsteval       = false; ///< Is it marked consteval?
+  bool                       isExplicit        = false; ///< Is it marked explicit?
   bool                       isInline          = false; ///< Is it marked inline?
+  bool                       isNoDiscard       = false; ///< Is it marked [[nodiscard]]?
+  bool                       isNoReturn        = false; ///< Is it marked [[noreturn]]?
   bool                       isConst           = false; ///< Is it marked const?
   bool                       isVolatile        = false; ///< Is it marked volatile?
   bool                       isRestrict        = false; ///< Is it marked restrict?


### PR DESCRIPTION
As the title says -  `explicit`, `[[noreturn]]` and `[[nodiscard]]` should be prefixed to function signatures where applicable.